### PR TITLE
Corrected issue where Id was a string in DNSRecord, although DigitalO…

### DIFF
--- a/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests.cs
+++ b/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests.cs
@@ -16,7 +16,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests : Te
     }
 
     [Fact]
-    public void OverwirtesUpdateDomainRecordRequestValues()
+    public void OverwritesUpdateDomainRecordRequestValues()
     {
         DNSRecordToDigitalOceanUpdateDomainRecordRequestConverter converter = new();
         DNSRecord record = new()

--- a/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests.cs
+++ b/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests.cs
@@ -23,6 +23,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests : Te
         {
             Data = "DNSData",
             Flags = 1,
+            Id = "12345",
             Name = "DNSName",
             Port = 1,
             Priority = 1,
@@ -36,6 +37,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests : Te
         {
             Data = "CreatData",
             Flags = 123,
+            Id = 12345,
             Name = "CreateName",
             Port = 123,
             Priority = 123,
@@ -49,6 +51,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests : Te
 
         Assert.Equal(record.Data, actual.Data);
         Assert.Equal(record.Flags, actual.Flags);
+        Assert.Equal(record.Id, actual.Id.ToString());
         Assert.Equal(record.Name, actual.Name);
         Assert.Equal(record.Port, actual.Port);
         Assert.Equal(record.Priority, actual.Priority);
@@ -67,6 +70,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverterTests : Te
         {
             Data = "DNSData",
             Flags = 1,
+            Id = "12345",
             Name = "DNSName",
             Port = 1,
             Priority = 1,

--- a/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/DigitalOceanClientTests.cs
+++ b/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/DigitalOceanClientTests.cs
@@ -176,7 +176,7 @@ public class DigitalOceanClientTests : TestBase, IDisposable
         DigitalOceanUpdateDomainRecordRequest request = new()
         {
             Data = "",
-            Id = "3352896",
+            Id = 3352896,
             Name = "test",
             Ttl = 1800,
             Type = DNSRecordType.A
@@ -195,7 +195,7 @@ public class DigitalOceanClientTests : TestBase, IDisposable
         DigitalOceanUpdateDomainRecordRequest request = new()
         {
             Data = "",
-            Id = "3352896",
+            Id = 3352896,
             Name = "test",
             Ttl = 1800,
             Type = DNSRecordType.A

--- a/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/DigitalOceanDNSRecordUpdaterTests.cs
+++ b/src/DDNSUpdate.Tests/Application/Providers/DigitalOcean/DigitalOceanDNSRecordUpdaterTests.cs
@@ -27,15 +27,17 @@ public class DigitalOceanDNSRecordUpdaterTests : TestBase
             new DNSRecord
             {
                 Data = "100.100.100.100",
+                Id = "12345",
                 TTL = 1800,
                 Type = DNSRecordType.A
             },
             new DNSRecord
             {
                 Data = "100.100.100.101",
+                Id = "67890",
                 TTL = 1800,
                 Type = DNSRecordType.A
-            },
+            }
         });
 
         IDigitalOceanClient client = A.Fake<IDigitalOceanClient>();
@@ -58,15 +60,17 @@ public class DigitalOceanDNSRecordUpdaterTests : TestBase
             new DNSRecord
             {
                 Data = "100.100.100.100",
+                Id = "12345",
                 TTL = 1800,
                 Type = DNSRecordType.A
             },
             new DNSRecord
             {
                 Data = "100.100.100.101",
+                Id = "67890",
                 TTL = 1800,
                 Type = DNSRecordType.A
-            },
+            }
         });
 
         IDigitalOceanClient client = A.Fake<IDigitalOceanClient>();

--- a/src/DDNSUpdate/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverter.cs
+++ b/src/DDNSUpdate/Application/Providers/DigitalOcean/Converters/DNSRecordToDigitalOceanUpdateDomainRecordRequestConverter.cs
@@ -11,7 +11,7 @@ public class DNSRecordToDigitalOceanUpdateDomainRecordRequestConverter : ITypeCo
         request ??= new DigitalOceanUpdateDomainRecordRequest();
         request.Data = record.Data;
         request.Flags = record.Flags;
-        request.Id = record.Id!;
+        request.Id = int.Parse(record.Id!);
         request.Name = record.Name;
         request.Port = record.Port;
         request.Priority = record.Priority;

--- a/src/DDNSUpdate/Application/Providers/DigitalOcean/Requests/DigitalOceanUpdateDomainRecordRequest.cs
+++ b/src/DDNSUpdate/Application/Providers/DigitalOcean/Requests/DigitalOceanUpdateDomainRecordRequest.cs
@@ -11,7 +11,7 @@ public class DigitalOceanUpdateDomainRecordRequest
     public int? Flags { get; set; }
 
     [JsonProperty("id")]
-    public string Id { get; set; } = default!;
+    public int Id { get; set; }
 
     [JsonProperty("name")]
     public string Name { get; set; } = default!;


### PR DESCRIPTION
Corrected issue where Id was a string in DNSRecord, although DigitalOcean requires it to be an integer on Update DNS record request.